### PR TITLE
Fix multiple null-values on outages

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2050,7 +2050,7 @@ function device_is_up($device, $record_perf = false)
             $type = 'up';
             $reason = $device['status_reason'];
 
-            $going_down = dbFetchCell('SELECT going_down FROM device_outages WHERE device_id=? AND up_again IS NULL', [$device['device_id']]);
+            $going_down = dbFetchCell('SELECT going_down FROM device_outages WHERE device_id=? AND up_again IS NULL ORDER BY going_down DESC', [$device['device_id']]);
             if (! empty($going_down)) {
                 $up_again = time() - $uptime;
                 if ($up_again <= $going_down) {
@@ -2059,9 +2059,8 @@ function device_is_up($device, $record_perf = false)
                 }
                 dbUpdate(
                     ['device_id' => $device['device_id'], 'up_again' => $up_again],
-                    'device_outages',
-                    'device_id=? and up_again is NULL',
-                    [$device['device_id']]
+                    'device_outages','device_id=? and going_down=? and up_again is NULL',
+                    [$device['device_id'], $going_down]
                 );
             }
         } else {


### PR DESCRIPTION
Fixes a specific issue where multiple null-values on device_outages-table prevent updating the correct outage details

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
